### PR TITLE
[encoder_audio_aac] 0.0.6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.6</span>**
+- add 'ac' parameter to ffmpeg command to ensure proper channel_layout field for compatiability with normalization plugin to avoid unsupported channel layout error
+
 **<span style="color:#56adda">0.0.5</span>**
 - Update FFmpeg helper
 - Remove support for v1 plugin executor

--- a/info.json
+++ b/info.json
@@ -15,5 +15,5 @@
         "on_worker_process": 0
     },
     "tags": "audio,encoder,ffmpeg,library file test",
-    "version": "0.0.5"
+    "version": "0.0.6"
 }

--- a/plugin.py
+++ b/plugin.py
@@ -151,8 +151,9 @@ class PluginStreamMapper(StreamMapper):
             if stream_info.get('channels'):
                 # Use 64K for the bitrate per channel
                 calculated_bitrate = self.calculate_bitrate(stream_info)
+                channels = int(stream_info.get('channels'))
                 stream_encoding += [
-                    '-b:a:{}'.format(stream_id), "{}k".format(calculated_bitrate)
+                    '-ac:a:{}'.format(stream_id), '{}'.format(channels), '-b:a:{}'.format(stream_id), "{}k".format(calculated_bitrate)
                 ]
 
         return {


### PR DESCRIPTION
added `-ac` parameter to ffmpeg command which creates the proper channel layout - this will avoid a potential unsupported channel layout error in some plugins.