### PR TITLE
[encoder_audio_aac] 0.0.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 
 **<span style="color:#56adda">0.0.6</span>**
+- add check in calculate_bitrate and custom_stream_mapping to set channels to 6 if channels > 6.  ffmpeg cannot encode > 6 channels of aac audio.
+
+**<span style="color:#56adda">0.0.6</span>**
 - add 'ac' parameter to ffmpeg command to ensure proper channel_layout field for compatiability with normalization plugin to avoid unsupported channel layout error
 
 **<span style="color:#56adda">0.0.5</span>**

--- a/info.json
+++ b/info.json
@@ -15,5 +15,5 @@
         "on_worker_process": 0
     },
     "tags": "audio,encoder,ffmpeg,library file test",
-    "version": "0.0.6"
+    "version": "0.0.7"
 }

--- a/plugin.py
+++ b/plugin.py
@@ -134,6 +134,8 @@ class PluginStreamMapper(StreamMapper):
     @staticmethod
     def calculate_bitrate(stream_info: dict):
         channels = stream_info.get('channels', 2)
+        if int(channels) > 6:
+            channels = 6
         return int(channels) * 64
 
     def test_stream_needs_processing(self, stream_info: dict):
@@ -152,6 +154,8 @@ class PluginStreamMapper(StreamMapper):
                 # Use 64K for the bitrate per channel
                 calculated_bitrate = self.calculate_bitrate(stream_info)
                 channels = int(stream_info.get('channels'))
+                if int(channels) > 6:
+                    channels = 6
                 stream_encoding += [
                     '-ac:a:{}'.format(stream_id), '{}'.format(channels), '-b:a:{}'.format(stream_id), "{}k".format(calculated_bitrate)
                 ]


### PR DESCRIPTION
In cases where user's source has > 6 audio channels in a stream, set the channels to 6 since ffmpeg cannot encoder > 6 channels using aac encoder.  Made fix in both custom_stream_mapping and calculate_bit_rate, the latter so that the total bit rate for is a function of 6 channels and not of > 6 channels.